### PR TITLE
Corrected h-feed title property

### DIFF
--- a/sempress/inc/semantics.php
+++ b/sempress/inc/semantics.php
@@ -211,7 +211,7 @@ function sempress_get_semantics($id = null) {
     case "site-title":
       if (!is_singular()) {
         $classes['itemprop'] = array('name');
-        $classes['class'] = array('p-title');
+        $classes['class'] = array('p-name');
       }
       break;
     case "site-description":


### PR DESCRIPTION
h-feed uses the “name” property rather than “title”, for consistency with other microformats2 vocabularies http://microformats.org/wiki/h-feed
