### PR TITLE
Asides / Statuses don't have titles

### DIFF
--- a/sempress/content-aside.php
+++ b/sempress/content-aside.php
@@ -11,11 +11,11 @@
 
 <article <?php sempress_post_id(); ?> <?php post_class(); ?><?php sempress_semantics("post"); ?>>
 	<?php if ( is_search() ) : // Only display Excerpts for search pages ?>
-	<div class="entry-summary p-summary entry-title p-name" itemprop="name description">
+	<div class="entry-summary p-summary p-name" itemprop="name description">
 		<?php the_excerpt(); ?>
 	</div><!-- .entry-summary -->
 	<?php else : ?>
-	<div class="entry-content e-content p-summary entry-title p-name" itemprop="name headline description articleBody">
+	<div class="entry-content e-content p-summary p-name" itemprop="name headline description articleBody">
 		<?php sempress_the_post_thumbnail('<p>', '</p>'); ?>
 		<?php the_content( __( 'Continue reading <span class="meta-nav">&rarr;</span>', 'sempress' ) ); ?>
 		<?php wp_link_pages( array( 'before' => '<div class="page-link">' . __( 'Pages:', 'sempress' ), 'after' => '</div>' ) ); ?>

--- a/sempress/content-status.php
+++ b/sempress/content-status.php
@@ -11,11 +11,11 @@
 
 <article <?php sempress_post_id(); ?> <?php post_class(); ?>>
 	<?php if ( is_search() ) : // Only display Excerpts for search pages ?>
-	<div class="entry-summary p-summary entry-title p-name" itemprop="name description">
+	<div class="entry-summary p-summary p-name" itemprop="name description">
 		<?php the_excerpt(); ?>
 	</div><!-- .entry-summary -->
 	<?php else : ?>
-	<div class="entry-content e-content p-summary entry-title p-name" itemprop="name headline description articleBody">
+	<div class="entry-content e-content p-summary p-name" itemprop="name headline description articleBody">
 		<?php sempress_the_post_thumbnail('<p>', '</p>'); ?>
 		<?php the_content( __( 'Continue reading <span class="meta-nav">&rarr;</span>', 'sempress' ) ); ?>
 		<?php wp_link_pages( array( 'before' => '<div class="page-link">' . __( 'Pages:', 'sempress' ), 'after' => '</div>' ) ); ?>


### PR DESCRIPTION
Removed entry-title from these post formats. The reasoning is that it's incorrect to say the content is the title. This also fixes an incompatibility with Post Kinds, which hides the title for notes causing empty containers to appear instead of statuses / asides.