### PR TITLE
Centralize post entry header code

### DIFF
--- a/sempress/content-gallery.php
+++ b/sempress/content-gallery.php
@@ -10,13 +10,7 @@
 ?>
 
 <article <?php sempress_post_id(); ?> <?php post_class(); ?><?php sempress_semantics( 'post' ); ?>>
-	<header class="entry-header">
-		<h1 class="entry-title p-name" itemprop="name headline"><a href="<?php the_permalink(); ?>" class="u-url url" title="<?php printf( esc_attr__( 'Permalink to %s', 'sempress' ), the_title_attribute( 'echo=0' ) ); ?>" rel="bookmark" itemprop="name"><?php the_title(); ?></a></h1>
-
-		<div class="entry-meta">
-			<?php sempress_posted_on(); ?>
-		</div><!-- .entry-meta -->
-	</header><!-- .entry-header -->
+	<?php get_template_part( 'entry', 'header' ); ?>
 
 	<?php if ( is_search() ) : // Only display Excerpts for search pages ?>
 	<div class="entry-summary p-summary" itemprop="description">

--- a/sempress/content-single.php
+++ b/sempress/content-single.php
@@ -5,15 +5,7 @@
  */
 ?>
 <article <?php sempress_post_id(); ?> <?php post_class(); ?><?php sempress_semantics( 'post' ); ?> itemref="site-publisher">
-	<header class="entry-header">
-		<h1 class="entry-title p-name" itemprop="name headline"><a href="<?php the_permalink(); ?>" class="u-url url" title="<?php printf( esc_attr__( 'Permalink to %s', 'sempress' ), the_title_attribute( 'echo=0' ) ); ?>" rel="bookmark" itemprop="url"><?php the_title(); ?></a></h1>
-
-		<?php if ( 'post' == get_post_type() ) : ?>
-		<div class="entry-meta">
-			<?php sempress_posted_on(); ?>
-		</div><!-- .entry-meta -->
-		<?php endif; ?>
-	</header><!-- .entry-header -->
+	<?php get_template_part( 'entry', 'header' ); ?>
 
 	<?php if ( is_search() ) : // Only display Excerpts for Search ?>
 	<div class="entry-summary p-summary" itemprop="description">

--- a/sempress/entry-header.php
+++ b/sempress/entry-header.php
@@ -1,7 +1,9 @@
 	<header class="entry-header">
 		<h1 class="entry-title p-name" itemprop="name headline"><a href="<?php the_permalink(); ?>" class="u-url url" title="<?php printf( esc_attr__( 'Permalink to %s', 'sempress' ), the_title_attribute( 'echo=0' ) ); ?>" rel="bookmark" itemprop="url"><?php the_title(); ?></a></h1>
 
+		<?php if ( 'post' == get_post_type() ) : ?>
 		<div class="entry-meta">
 			<?php sempress_posted_on(); ?>
 		</div><!-- .entry-meta -->
+		<?php endif; ?>
 	</header><!-- .entry-header -->


### PR DESCRIPTION
Fixes #63 #64

This PR moves all header code for post type entries to one single template part, which makes the code more readable and maintainable.